### PR TITLE
Fix for right aligned nodes being set to left aligned in Unity.

### DIFF
--- a/UnityFigmaBridge/Editor/Nodes/NodeTransformManager.cs
+++ b/UnityFigmaBridge/Editor/Nodes/NodeTransformManager.cs
@@ -109,7 +109,7 @@ namespace UnityFigmaBridge.Editor.Nodes
             var anchorsX = constraint.horizontal switch
             {
                 LayoutConstraint.HorizontalLayoutConstraint.LEFT => new Vector2(0, 0),
-                LayoutConstraint.HorizontalLayoutConstraint.RIGHT => new Vector2(0, 0),
+                LayoutConstraint.HorizontalLayoutConstraint.RIGHT => new Vector2(1, 1),
                 LayoutConstraint.HorizontalLayoutConstraint.CENTER => new Vector2(0.5f, 0.5f),
                 LayoutConstraint.HorizontalLayoutConstraint.LEFT_RIGHT => new Vector2(0, 1),
                 LayoutConstraint.HorizontalLayoutConstraint.SCALE => new Vector2(0, 1),


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/12634471/219529250-8afc7e34-653d-4e0b-aa99-8ef944d59409.PNG)

After:
![after](https://user-images.githubusercontent.com/12634471/219529269-e265ef16-4481-4d3b-8970-8232494265d8.PNG)
![after (stretched)](https://user-images.githubusercontent.com/12634471/219529567-28bb0fb0-1e0c-435c-9bdc-2757bf3aabfc.PNG)

Tested in Unity version 2021.3.10f1