### PR TITLE
Fix layout grid alignment

### DIFF
--- a/UnityFigmaBridge/Editor/FigmaApi/FigmaApiData.cs
+++ b/UnityFigmaBridge/Editor/FigmaApi/FigmaApiData.cs
@@ -630,7 +630,7 @@ namespace UnityFigmaBridge.Editor.FigmaApi
             MIN, // Grid starts at the left or top of the frame
             STRETCH, // Grid is stretched to fit the frame
             CENTER, // Grid is center aligned
-            MAX,
+            MAX, // Grid is right or bottom
         }
 
         /// <summary>


### PR DESCRIPTION
When Rows Type is set to Bottom or Columns Type is set to Right in a grid layout, the enum definition does not exist and the following error occurs.
I added an enumerated type definition.

<details>
<summary>Error Description</summary>
Error downloading Figma document - Check your personal access key and document url are correct
 System.Exception: Problem decoding Figma document JSON Newtonsoft.Json.JsonSerializationException: Error converting value "MAX" to type 'UnityFigmaBridge.Editor.FigmaApi.LayoutGrid+Alignment'. Path 'document.children[1].children[0].children[0].layoutGrids[4].alignment', line 1, position 6442. ---> System.ArgumentException: Requested value 'MAX' was not found.
</details>