### PR TITLE
Fix the output color of FigmaImageShader

### DIFF
--- a/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
+++ b/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
@@ -321,7 +321,7 @@ namespace UnityFigmaBridge.Editor.FigmaApi
                     textureImporter.alphaIsTransparency = true;
                     textureImporter.mipmapEnabled = true; // We'll enable mip maps to stop issues at lower resolutions
                     textureImporter.textureCompression = TextureImporterCompression.Uncompressed;
-                    textureImporter.sRGBTexture = downloadItem.FileType == FigmaDownloadQueueItem.FigmaFileType.ServerRenderedImage;
+                    textureImporter.sRGBTexture = true;
 
 
                     switch (downloadItem.FileType)

--- a/UnityFigmaBridge/Runtime/Resources/Shaders/FigmaImageShader.shader
+++ b/UnityFigmaBridge/Runtime/Resources/Shaders/FigmaImageShader.shader
@@ -26,6 +26,8 @@ Shader "Figma/FigmaImageShader"
         _CornerRadius ("Corner Radius", Vector) = (0, 0, 0, 0)
         
         _StrokeWidth ("Stroke Width", Float) = 2
+        _StrokeColor ("Stroke Color", Color) = (1,1,1,1)
+        _FillColor ("Fill Color", Color) = (1,1,1,1)
         
         // End Figma properties
     }
@@ -252,6 +254,14 @@ Shader "Figma/FigmaImageShader"
                 return length(r-p) * sign(p.y-r.y);
             }
 
+            float4 GammaToLinearIfNeeded(float4 color)
+            {
+            #if UNITY_COLORSPACE_GAMMA
+                return color;
+            #else
+                return float4(GammaToLinearSpace(color.rgb), color.a);
+            #endif
+            }
         
             float4 GetGradientColor(float percAlongGradient)
             {
@@ -261,7 +271,10 @@ Shader "Figma/FigmaImageShader"
                 for ( int i=1; i<_GradientNumStops-1; ++i ) {
                     gradientColor = lerp(gradientColor, _GradientColors[i+1], smoothstep( _GradientStops[i],  _GradientStops[i+1], percAlongGradient ) );
                 }
-                return gradientColor;
+
+                // If the setting of the color space is set to Linear,
+                // convert the color to linear space after the interpolation.
+                return  GammaToLinearIfNeeded(gradientColor);
             }
 
 
@@ -399,11 +412,7 @@ Shader "Figma/FigmaImageShader"
                     clip (color.a - 0.001);
                 #endif
 
-                #if UNITY_COLORSPACE_GAMMA
-                     return color;
-                #else
-                    return float4(GammaToLinearSpace( color.rgb),color.a);
-                #endif
+                return color;
                 
             }
 

--- a/UnityFigmaBridge/Runtime/UI/FigmaImage.cs
+++ b/UnityFigmaBridge/Runtime/UI/FigmaImage.cs
@@ -413,7 +413,7 @@ namespace UnityFigmaBridge.Runtime.UI
 
             // If the player settings is set to linear, we need to convert the vertex color to gamma space
             // because FigmaImageShader treats the color as in gamma space.
-            Color32 color32 = LinearToGammaSpaceIfNeeded(color);
+            Color32 color32 = color;
             vh.Clear();
             // Order is TL, BL, BR, TR
             vh.AddVert(new Vector3(v.x, v.y), color32, texCoords[0],new Vector4(0f, 0,rtSize.x,rtSize.y), Vector3.zero, Vector4.zero);
@@ -502,6 +502,10 @@ namespace UnityFigmaBridge.Runtime.UI
                 var percentGradientLength = i / (float)(i - 1);
                 gradientColors[i].a= m_FillGradient.Evaluate(percentGradientLength).a;
             }
+
+            // Since color interpolation must be done in gamma space,
+            // the gradient colors are passed to the shader without conversion to linear space,
+            // even if the color space setting is set to linear.
             mat.SetColorArray(s_GradientColorsPropertyID,gradientColors);
             mat.SetFloatArray(s_GradientStopsPropertyID,gradientStops);
             mat.SetFloat(s_GradientNumStopsPropertyID,gradientStopCount);
@@ -530,25 +534,6 @@ namespace UnityFigmaBridge.Runtime.UI
             AdditionalCanvasShaderChannels canvasAdditionalShaderChannels = canvas.additionalShaderChannels;
             canvasAdditionalShaderChannels |= AdditionalCanvasShaderChannels.TexCoord1;
             canvas.additionalShaderChannels = canvasAdditionalShaderChannels;
-        }
-
-        /// <summary>
-        /// Change the color space from linear to gamma if needed
-        /// </summary>
-        /// <param name="inColor">Input color</param>
-        private Color LinearToGammaSpaceIfNeeded(Color inColor)
-        {
-            if (QualitySettings.activeColorSpace == ColorSpace.Gamma)
-            {
-                return inColor;
-            }
-
-            Color outColor;
-            outColor.r = Mathf.LinearToGammaSpace(inColor.r);
-            outColor.g = Mathf.LinearToGammaSpace(inColor.g);
-            outColor.b = Mathf.LinearToGammaSpace(inColor.b);
-            outColor.a = inColor.a;
-            return outColor;
         }
     }
 }


### PR DESCRIPTION
It seems the color of a texture sampled in a shader always in linear color space, so there is no need to call `GammaToLinearSpace`.

At least in our environment (linear work flow), to output as-is seems to be correct…


https://docs.unity3d.com/2021.3/Documentation/Manual/LinearRendering-LinearOrGammaWorkflow.html

> Textures tend to be saved in gamma color space, while Shaders expect linear color space. 

> You can work in linear color space if your Textures were created in linear or gamma color space. Gamma color space Texture inputs to the linear color space Shader program are supplied to the Shader with gamma correction removed from them.

> For colors, this conversion is applied implicitly, because the Unity Editor already converts the values to floating point before passing them to the GPU as constants. When sampling Textures, the GPU automatically removes the gamma correction, converting the result to linear space.
