### PR TITLE
Fix the output path of FigmaOutput.json

### DIFF
--- a/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
+++ b/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
@@ -114,7 +114,7 @@ namespace UnityFigmaBridge.Editor.FigmaApi
                 throw new Exception($"Problem decoding Figma document JSON {e.ToString()}");
             }
 
-            if (writeFile) File.WriteAllText("Assets\\" + WRITE_FILE_PATH, webRequest.downloadHandler.text);
+            if (writeFile) File.WriteAllText(Path.Combine("Assets", WRITE_FILE_PATH), webRequest.downloadHandler.text);
             return figmaFile;
         }
 


### PR DESCRIPTION
If you commit the FigmaOutput.json output on a Mac, you will not be able to pull it on Windows.