### PR TITLE
Improve the stroke color and vertex color with Linear workflow.

### DIFF
--- a/UnityFigmaBridge/Runtime/Resources/Shaders/FigmaImageShader.shader
+++ b/UnityFigmaBridge/Runtime/Resources/Shaders/FigmaImageShader.shader
@@ -25,7 +25,6 @@ Shader "Figma/FigmaImageShader"
         // Corner radius defines corner for rectangle shapes, one per corner
         _CornerRadius ("Corner Radius", Vector) = (0, 0, 0, 0)
         
-        _StrokeColor ("Stroke Color", Color) = (1,1,1,1)
         _StrokeWidth ("Stroke Width", Float) = 2
         
         // End Figma properties

--- a/UnityFigmaBridge/Runtime/UI/FigmaImage.cs
+++ b/UnityFigmaBridge/Runtime/UI/FigmaImage.cs
@@ -410,7 +410,10 @@ namespace UnityFigmaBridge.Runtime.UI
            }
 
            // Largely this is the the same as Graphic original, but with extra UV Channels settings
-            Color32 color32 = color;
+
+            // If the player settings is set to linear, we need to convert the vertex color to gamma space
+            // because FigmaImageShader treats the color as in gamma space.
+            Color32 color32 = LinearToGammaSpaceIfNeeded(color);
             vh.Clear();
             // Order is TL, BL, BR, TR
             vh.AddVert(new Vector3(v.x, v.y), color32, texCoords[0],new Vector4(0f, 0,rtSize.x,rtSize.y), Vector3.zero, Vector4.zero);
@@ -528,10 +531,24 @@ namespace UnityFigmaBridge.Runtime.UI
             canvasAdditionalShaderChannels |= AdditionalCanvasShaderChannels.TexCoord1;
             canvas.additionalShaderChannels = canvasAdditionalShaderChannels;
         }
-        
+
+        /// <summary>
+        /// Change the color space from linear to gamma if needed
+        /// </summary>
+        /// <param name="inColor">Input color</param>
+        private Color LinearToGammaSpaceIfNeeded(Color inColor)
+        {
+            if (QualitySettings.activeColorSpace == ColorSpace.Gamma)
+            {
+                return inColor;
+            }
+
+            Color outColor;
+            outColor.r = Mathf.LinearToGammaSpace(inColor.r);
+            outColor.g = Mathf.LinearToGammaSpace(inColor.g);
+            outColor.b = Mathf.LinearToGammaSpace(inColor.b);
+            outColor.a = inColor.a;
+            return outColor;
+        }
     }
-
-
-
-
 }


### PR DESCRIPTION
This PR try to improve the current behavior of the stroke color and the vertex color of FigmaImage shader with Linear color space.

First of all, the following figures shows the difference of the behavior of FigmaImage shader between Gamma and Linear space. 

UnityFigmaBridge 1.0.7 (Gamma)
<img width="819" alt="ShapesScreen_Gamma(current)" src="https://github.com/simonoliver/UnityFigmaBridge/assets/1140630/1403faa8-6683-4a49-a454-bd9434793635">

UnityFigmaBridge 1.0.7 (Linear)
<img width="819" alt="ShapesScreen_Linear(current)" src="https://github.com/simonoliver/UnityFigmaBridge/assets/1140630/c533dd76-83ec-473b-a973-14f5227160ed">

You can see that the stroke color of the star shape at the right side differs between the first and the second figure. (Also, the background color of the top bar and the bottom dock differs but it seems to be difficult to fix perfectly with current version of Unity. 
https://forum.unity.com/threads/ui-alpha-blending-in-linear-colour-space-projects.607186/)

The reason is FigmaImage shader treats the colors as in gamma space but the stroke colors and the vertex colors are not converted to gamma space when the color space setting is set to `Linear`.

### About the stroke color
The stroke color is passed to the shader through `_StrokeColor` variable.
With `Linear` color space setting, the colors declared at `Properties` section at a shader seems to be converted to linear color space if it doesn't have `[HDR]` attribute.

So I simply removed the declaration of _StrokeColor at `Properties` section in the shader. (like _FillColor)
Another solution is to add the HDR attribute to _StrokeColor
```
[HDR] _StrokeColor ("Stroke Color", Color) = (1,1,1,1)
```
or add gamma conversion to the color.
```
// m_StrokeColor is doublely gammaed but is degammaed when it passed to the shader.
mat.SetColor(s_StrokeColorPropertyID, LinearToGammaSpaceIfNeeded(m_StrokeColor));
```

The following figures show that this change improve the stroke color.

UnityFigmaBridge 1.0.7 (Gamma) with this PR
<img width="820" alt="ShapesScreen_Gamma(improved)" src="https://github.com/simonoliver/UnityFigmaBridge/assets/1140630/3b9d4fb5-6dfb-46c1-8e6b-c3423a2ced08">

UnityFigmaBridge 1.0.7 (Linear) with this PR
<img width="820" alt="ShapesScreen_Linear(improved)" src="https://github.com/simonoliver/UnityFigmaBridge/assets/1140630/7edcdd34-d626-4790-a1b6-cea395e17ee4">


### About the vertex color
If you change `Color` property of FigmaImage, you can change the vertex color of the mesh.
And the vertex color also have to be converted to gamma space.

For example, I set the `Color` of the `SpeechBubble` by `EC2049` color.
<img width="319" alt="Color" src="https://github.com/simonoliver/UnityFigmaBridge/assets/1140630/a4e6d3a3-d51a-4c82-b305-b72e0251b7a3">

UnityFigmaBridge 1.0.7 (Linear)
<img width="820" alt="VertexColorExample(current)" src="https://github.com/simonoliver/UnityFigmaBridge/assets/1140630/d80a9af0-db33-444a-9c46-ee33eb132da1">

UnityFigmaBridge 1.0.7 (Linear) with this PR
<img width="820" alt="VertexColorExample(improved)" src="https://github.com/simonoliver/UnityFigmaBridge/assets/1140630/bbe27785-da23-42c1-b787-b07323ef978f">

To improve this behavior, I add the color conversion to gamma space.