### PR TITLE
Feature update prefab

### DIFF
--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -189,8 +190,15 @@ namespace UnityFigmaBridge.Editor.Components
             {
                 // We might have issue with nested elements so need try catch loop
                 // TODO - Check for recurisve nested components
-                PrefabUtility.SaveAsPrefabAsset(prefabContents, assetPath);
-                
+                if (File.Exists(assetPath) && figmaImportProcessData.Settings.UpdateExistingPrefab) {
+                    Debug.Log("UpdatePrefab: " + prefabContents.name + ", " + assetPath);
+                    PrefabUtility.ApplyPrefabInstance(prefabContents, InteractionMode.AutomatedAction);
+
+                }
+                {
+                    Debug.Log("SavePrefab: " + prefabContents.name + ", " + assetPath);
+                    PrefabUtility.SaveAsPrefabAsset(prefabContents, assetPath);
+                }
                 // Apply changes to the instance as modifications
                 foreach (var modifiedPrefabInstance in modifiedPrefabInstances)
                 {

--- a/UnityFigmaBridge/Editor/Settings/UnityFigmaBridgeSettings.cs
+++ b/UnityFigmaBridge/Editor/Settings/UnityFigmaBridgeSettings.cs
@@ -36,9 +36,12 @@ namespace UnityFigmaBridge.Editor.Settings
         
         [Tooltip("If false, the generator will not attempt to build any nodes marked for export")]
         public bool GenerateNodesMarkedForExport = true;
-        
+
         [Tooltip("If true, download only selected pages and screens")]
         public bool OnlyImportSelectedPages = false;
+
+        [Tooltip("If true, update existing screens prefabs")]
+        public bool UpdateExistingPrefab = false;
 
         [HideInInspector]
         public List<FigmaPageData> PageDataList = new ();

--- a/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
+++ b/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
@@ -109,7 +109,7 @@ namespace UnityFigmaBridge.Editor
                 pageNodeList = pageNodeList.Where(p => enabledPageIdList.Contains(p.id)).ToList();
             }
 
-            await ImportDocument(s_UnityFigmaBridgeSettings.FileId, figmaFile, pageNodeList);
+            await ImportDocument(s_UnityFigmaBridgeSettings.FileId, figmaFile, pageNodeList, s_UnityFigmaBridgeSettings.UpdateExistingPrefab);
             
         }
 
@@ -319,7 +319,7 @@ namespace UnityFigmaBridge.Editor
             return null;
         }
 
-        private static async Task ImportDocument(string fileId, FigmaFile figmaFile, List<Node> downloadPageNodeList)
+        private static async Task ImportDocument(string fileId, FigmaFile figmaFile, List<Node> downloadPageNodeList, bool updatePrefabs)
         {
 
             // Build a list of page IDs to download
@@ -327,7 +327,7 @@ namespace UnityFigmaBridge.Editor
             
             // Ensure we have all required directories, and remove existing files
             // TODO - Once we move to processing only differences, we won't remove existing files
-            FigmaPaths.CreateRequiredDirectories();
+            FigmaPaths.CreateRequiredDirectories(updatePrefabs);
             
             // Next build a list of all externally referenced components not included in the document (eg
             // from external libraries) and download

--- a/UnityFigmaBridge/Editor/Utils/FigmaPaths.cs
+++ b/UnityFigmaBridge/Editor/Utils/FigmaPaths.cs
@@ -107,7 +107,7 @@ namespace UnityFigmaBridge.Editor.Utils
             return System.Text.RegularExpressions.Regex.Replace(name, invalidRegStr, "_");
         }
 
-        public static void CreateRequiredDirectories()
+        public static void CreateRequiredDirectories(bool updatePrefabs)
         {
             
             //  Create directory for pages if required 
@@ -116,23 +116,30 @@ namespace UnityFigmaBridge.Editor.Utils
                 Directory.CreateDirectory(FigmaPagePrefabFolder);
             }
 
-            // Remove existing prefabs for pages
-            foreach (var file in new DirectoryInfo(FigmaPagePrefabFolder).GetFiles())
+            if (!updatePrefabs)
             {
-                file.Delete(); 
+                // Remove existing prefabs for pages
+                foreach (var file in new DirectoryInfo(FigmaPagePrefabFolder).GetFiles())
+                {
+                    file.Delete();
+                }
             }
-            
+
             //  Create directory for flowScreen prefabs if required 
             if (!Directory.Exists(FigmaScreenPrefabFolder))
             {
                 Directory.CreateDirectory(FigmaScreenPrefabFolder);
             }
-            // Remove existing flowScreen prefabs
-            foreach (FileInfo file in  new DirectoryInfo(FigmaScreenPrefabFolder).GetFiles())
+
+            if (!updatePrefabs)
             {
-                file.Delete(); 
+                // Remove existing flowScreen prefabs
+                foreach (FileInfo file in new DirectoryInfo(FigmaScreenPrefabFolder).GetFiles())
+                {
+                    file.Delete();
+                }
             }
-            
+
             if (!Directory.Exists(FigmaComponentPrefabFolder))
             {
                 Directory.CreateDirectory(FigmaComponentPrefabFolder);


### PR DESCRIPTION
Ability to retain generated Prefabs from previous "Sync".
This allows us to create Prefab Variants that can retain changes with subsequent "Sync Document" actions, allowing us to make changes to both the Prefab Variant (development) and the Figma file (design and ux). This allows our workflow to have incremental changes as we continuously build the Figma Prototype into a Unity Application.