### PR TITLE
Change SpriteImportMode

### DIFF
--- a/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
+++ b/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
@@ -329,6 +329,7 @@ namespace UnityFigmaBridge.Editor.FigmaApi
                     // Set the properties for the texture, to mark as a sprite and with alpha transparency and no compression
                     TextureImporter textureImporter = (TextureImporter) AssetImporter.GetAtPath(downloadItem.FilePath);
                     textureImporter.textureType = TextureImporterType.Sprite;
+                    textureImporter.spriteImportMode = SpriteImportMode.Single;
                     textureImporter.alphaIsTransparency = true;
                     textureImporter.mipmapEnabled = true; // We'll enable mip maps to stop issues at lower resolutions
                     textureImporter.textureCompression = TextureImporterCompression.Uncompressed;


### PR DESCRIPTION
https://discussions.unity.com/t/sprite-mode-default-to-multiple/921914/3

In Unity 6 or Unity 2023. Default SpriteImportMode is multiple. So, If we only change textureType, sprite are not created. 
For current Unity Editor, We need to change spriteImportMode too for get sprite.
Thank you.